### PR TITLE
Reduce number of filesystem calls made when retrieving items from the directory

### DIFF
--- a/lib/adrian/directory_queue.rb
+++ b/lib/adrian/directory_queue.rb
@@ -29,10 +29,9 @@ module Adrian
     end
 
     def pop_item
-      items.each do |item|
+      while item = items.shift
         return item if reserve(item)
       end
-
       nil
     end
 
@@ -69,9 +68,12 @@ module Adrian
     end
 
     def items
-      items = files.map { |file| wrap_item(file) }
-      items.reject! { |item| !item.exist? || filter?(item) }
-      items.sort_by(&:updated_at)
+      return @items if @items && @items.length > 0
+      @items = begin
+        items = files.map { |file| wrap_item(file) }
+        items.reject! { |item| !item.exist? || filter?(item) }
+        items.sort_by(&:updated_at)
+      end
     end
 
     def files

--- a/lib/adrian/directory_queue.rb
+++ b/lib/adrian/directory_queue.rb
@@ -51,6 +51,10 @@ module Adrian
       items.include?(item)
     end
 
+    def items_length
+      @items ? @items.length : 0
+    end
+
     protected
 
     def wrap_item(value)

--- a/lib/adrian/directory_queue.rb
+++ b/lib/adrian/directory_queue.rb
@@ -73,11 +73,9 @@ module Adrian
 
     def items
       return @items if @items && @items.length > 0
-      @items = begin
-        items = files.map { |file| wrap_item(file) }
-        items.reject! { |item| !item.exist? || filter?(item) }
-        items.sort_by(&:updated_at)
-      end
+      @items = files.map! { |file| wrap_item(file) }
+      @items.reject! { |item| !item.exist? || filter?(item) }
+      @items.sort_by!(&:updated_at)
     end
 
     def files

--- a/lib/adrian/directory_queue.rb
+++ b/lib/adrian/directory_queue.rb
@@ -32,7 +32,6 @@ module Adrian
       while item = items.shift
         return item if reserve(item)
       end
-      nil
     end
 
     def push_item(value)
@@ -49,10 +48,6 @@ module Adrian
     def include?(value)
       item = wrap_item(value)
       items.include?(item)
-    end
-
-    def items_length
-      @items ? @items.length : 0
     end
 
     protected

--- a/test/directory_queue_test.rb
+++ b/test/directory_queue_test.rb
@@ -93,12 +93,64 @@ describe Adrian::DirectoryQueue do
         assert_equal nil, @q.pop
       end
 
-      it "set's the logger on the item" do
+      it "sets the logger on the item" do
         @item.logger.must_be_nil
         @q.push(@item)
         @q.pop.logger.must_equal @logger
       end
 
+      describe "items list" do
+        before do
+          @item1 = Tempfile.new('item1-').path
+          @item2 = Tempfile.new('item2-').path
+          @item3 = Tempfile.new('item3-').path
+          @item4 = Tempfile.new('item4-').path
+        end
+
+        it "populates items list on first pop" do
+          @q.items_length.must_equal 0
+          @q.push(@item1)
+          @q.push(@item2)
+          @q.items_length.must_equal 0
+
+          @q.pop
+          @q.items_length.must_equal 1
+        end
+
+        it "populates items list when #include? is used" do
+          @q.push(@item1)
+          @q.items_length.must_equal 0
+          assert @q.include?(@item1)
+        end
+
+        describe "only repopulates items list from directory after its current contents are emptied" do
+          before do
+            @q.push(@item1)
+            @q.push(@item2)
+            @q.pop
+            @q.items_length.must_equal 1
+
+            @q.push(@item3)
+            @q.push(@item4)
+            refute @q.include?(@item4)
+            @q.items_length.must_equal 1
+
+            @q.pop
+            @q.items_length.must_equal 0
+          end
+
+          it "and #pop is called" do
+            @q.pop
+            assert @q.include?(@item4)
+            @q.items_length.must_equal 1
+          end
+
+          it "and #include? is called" do
+            assert @q.include?(@item3)
+            @q.items_length.must_equal 2
+          end
+        end
+      end
     end
 
     describe 'push' do

--- a/test/directory_queue_test.rb
+++ b/test/directory_queue_test.rb
@@ -108,18 +108,18 @@ describe Adrian::DirectoryQueue do
         end
 
         it "populates items list on first pop" do
-          @q.items_length.must_equal 0
+          items_count.must_equal 0
           @q.push(@item1)
           @q.push(@item2)
-          @q.items_length.must_equal 0
+          items_count.must_equal 0
 
           @q.pop
-          @q.items_length.must_equal 1
+          items_count.must_equal 1
         end
 
         it "populates items list when #include? is used" do
           @q.push(@item1)
-          @q.items_length.must_equal 0
+          items_count.must_equal 0
           assert @q.include?(@item1)
         end
 
@@ -128,26 +128,26 @@ describe Adrian::DirectoryQueue do
             @q.push(@item1)
             @q.push(@item2)
             @q.pop
-            @q.items_length.must_equal 1
+            items_count.must_equal 1
 
             @q.push(@item3)
             @q.push(@item4)
             refute @q.include?(@item4)
-            @q.items_length.must_equal 1
+            items_count.must_equal 1
 
             @q.pop
-            @q.items_length.must_equal 0
+            items_count.must_equal 0
           end
 
           it "and #pop is called" do
             @q.pop
             assert @q.include?(@item4)
-            @q.items_length.must_equal 1
+            items_count.must_equal 1
           end
 
           it "and #include? is called" do
             assert @q.include?(@item3)
-            @q.items_length.must_equal 2
+            items_count.must_equal 2
           end
         end
       end
@@ -199,7 +199,10 @@ describe Adrian::DirectoryQueue do
         filter.duration.must_equal 300
       end
     end
+  end
 
+  def items_count
+    (@q.instance_variable_get(:@items) || []).size
   end
 
 end


### PR DESCRIPTION
This stores a list of the directory's items and iterates those until they've all been processed before calling `Dir.glob` again to refill the list. This prevents us from calling `Dir.glob` seemingly once per file processed, and also from calling `stat` many times via `wrap_item`.

/cc @zendesk/zendesk-email @zendesk/mail 