### PR TITLE
[EM-2629] Adds Queue#last_retry?(item)

### DIFF
--- a/lib/adrian/queue.rb
+++ b/lib/adrian/queue.rb
@@ -36,6 +36,14 @@ module Adrian
       @max_age ||= @options[:max_age]
     end
 
+    def last_retry?(item)
+      item && max_age && delay && item.age >= (max_age - delay)
+    end
+
+    def delay
+      @delay ||= @options[:delay]
+    end
+
     def pop_item
       raise "#{self.class.name}#pop_item is not defined"
     end


### PR DESCRIPTION
### Description
"Jobs" queued by Adrian are not currently aware of their retry status - this allows the queue to be queried for an item's status, when a `max_age` and `delay` (retry delay) are supplied.

### References
- [EM-2629](https://zendesk.atlassian.net/browse/EM-2629)

### Risks
- Low risk change, added with tests and not used by the library itself. Will be tested in MPQ/MTC.
