### PR TITLE
[EM-6860] Files should have their access times modified prior to being moved

### DIFF
--- a/lib/adrian/directory_queue.rb
+++ b/lib/adrian/directory_queue.rb
@@ -24,7 +24,7 @@ module Adrian
       @available_path = options.fetch(:path)
       @reserved_path  = options.fetch(:reserved_path, default_reserved_path)
       @logger         = options[:logger]
-      @touch_first    = options[:touch_first]
+      @touch_first    = options.fetch(:touch_first, false)
       filters << Filters::FileLock.new(:duration => options[:lock_duration], :reserved_path => reserved_path)
       filters << Filters::Delay.new(:duration => options[:delay]) if options[:delay]
     end

--- a/lib/adrian/directory_queue.rb
+++ b/lib/adrian/directory_queue.rb
@@ -36,8 +36,8 @@ module Adrian
 
     def push_item(value)
       item = wrap_item(value)
-      item.move(available_path)
       item.touch
+      item.move(available_path)
       self
     end
 
@@ -59,8 +59,8 @@ module Adrian
     end
 
     def reserve(item)
-      item.move(reserved_path)
       item.touch
+      item.move(reserved_path)
       true
     rescue Errno::ENOENT => e
       false

--- a/lib/adrian/directory_queue.rb
+++ b/lib/adrian/directory_queue.rb
@@ -36,8 +36,8 @@ module Adrian
 
     def push_item(value)
       item = wrap_item(value)
-      item.touch
       item.move(available_path)
+      item.touch
       self
     end
 
@@ -59,8 +59,8 @@ module Adrian
     end
 
     def reserve(item)
-      item.touch
       item.move(reserved_path)
+      item.touch
       true
     rescue Errno::ENOENT => e
       false

--- a/lib/adrian/directory_queue.rb
+++ b/lib/adrian/directory_queue.rb
@@ -31,19 +31,13 @@ module Adrian
 
     def pop_item
       while item = items.shift
-        return item if reserve(item)
+        return item if reserve(item, reserved_path)
       end
     end
 
     def push_item(value)
       item = wrap_item(value)
-      if @touch_first
-        item.touch
-        item.move(available_path)
-      else
-        item.move(available_path)
-        item.touch
-      end
+      reserve(item, available_path)
       self
     end
 
@@ -64,12 +58,12 @@ module Adrian
       item
     end
 
-    def reserve(item)
+    def reserve(item, path)
       if @touch_first
         item.touch
-        item.move(reserved_path)
+        item.move(path)
       else
-        item.move(reserved_path)
+        item.move(path)
         item.touch
       end
       true

--- a/lib/adrian/directory_queue.rb
+++ b/lib/adrian/directory_queue.rb
@@ -24,6 +24,7 @@ module Adrian
       @available_path = options.fetch(:path)
       @reserved_path  = options.fetch(:reserved_path, default_reserved_path)
       @logger         = options[:logger]
+      @touch_first    = options[:touch_first]
       filters << Filters::FileLock.new(:duration => options[:lock_duration], :reserved_path => reserved_path)
       filters << Filters::Delay.new(:duration => options[:delay]) if options[:delay]
     end
@@ -36,8 +37,13 @@ module Adrian
 
     def push_item(value)
       item = wrap_item(value)
-      item.move(available_path)
-      item.touch
+      if @touch_first
+        item.touch
+        item.move(available_path)
+      else
+        item.move(available_path)
+        item.touch
+      end
       self
     end
 
@@ -59,8 +65,13 @@ module Adrian
     end
 
     def reserve(item)
-      item.move(reserved_path)
-      item.touch
+      if @touch_first
+        item.touch
+        item.move(reserved_path)
+      else
+        item.move(reserved_path)
+        item.touch
+      end
       true
     rescue Errno::ENOENT => e
       false

--- a/lib/adrian/directory_queue.rb
+++ b/lib/adrian/directory_queue.rb
@@ -17,7 +17,7 @@ module Adrian
     # Note:
     # There is the possibility of an item being consumed by multiple processes when its still in the queue after its lock expires.
     # The reason for allowing this is:
-    #   1. It's much simpler than introducing a seperate monitoring process to handle lock expiry.
+    #   1. It's much simpler than introducing a separate monitoring process to handle lock expiry.
     #   2. This is an acceptable and rare event. e.g. it only happens when the process working on the item crashes without being able to release the lock
     def initialize(options = {})
       super

--- a/lib/adrian/version.rb
+++ b/lib/adrian/version.rb
@@ -1,3 +1,3 @@
 module Adrian
-  VERSION = '2.0.2'
+  VERSION = '2.0.2.pre'
 end

--- a/lib/adrian/version.rb
+++ b/lib/adrian/version.rb
@@ -1,3 +1,3 @@
 module Adrian
-  VERSION = '2.0.2.pre'
+  VERSION = '2.0.2'
 end

--- a/lib/adrian/version.rb
+++ b/lib/adrian/version.rb
@@ -1,3 +1,3 @@
 module Adrian
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end

--- a/test/array_queue_test.rb
+++ b/test/array_queue_test.rb
@@ -3,15 +3,15 @@ require_relative 'test_helper'
 describe Adrian::ArrayQueue do
   it 'should allow construction with an array' do
     q = Adrian::ArrayQueue.new([1,2,3])
-    _(q.pop.value).must_equal 1
-    _(q.pop.value).must_equal 2
-    _(q.pop.value).must_equal 3
-    _(q.pop).must_be_nil
+    q.pop.value.must_equal 1
+    q.pop.value.must_equal 2
+    q.pop.value.must_equal 3
+    q.pop.must_be_nil
   end
 
   it 'should allow construction without an array' do
     q = Adrian::ArrayQueue.new
-    _(q.pop).must_be_nil
+    q.pop.must_be_nil
   end
 
   it 'should act as a queue' do
@@ -21,13 +21,13 @@ describe Adrian::ArrayQueue do
     q.push(2)
     q.push(3)
 
-    _(q.length).must_equal 3
+    q.length.must_equal 3
 
-    _(q.pop.value).must_equal 1
-    _(q.pop.value).must_equal 2
-    _(q.pop.value).must_equal 3
-    _(q.pop).must_be_nil
+    q.pop.value.must_equal 1
+    q.pop.value.must_equal 2
+    q.pop.value.must_equal 3
+    q.pop.must_be_nil
 
-    _(q.length).must_equal 0
+    q.length.must_equal 0
   end
 end

--- a/test/array_queue_test.rb
+++ b/test/array_queue_test.rb
@@ -3,15 +3,15 @@ require_relative 'test_helper'
 describe Adrian::ArrayQueue do
   it 'should allow construction with an array' do
     q = Adrian::ArrayQueue.new([1,2,3])
-    q.pop.value.must_equal 1
-    q.pop.value.must_equal 2
-    q.pop.value.must_equal 3
-    q.pop.must_be_nil
+    _(q.pop.value).must_equal 1
+    _(q.pop.value).must_equal 2
+    _(q.pop.value).must_equal 3
+    _(q.pop).must_be_nil
   end
 
   it 'should allow construction without an array' do
     q = Adrian::ArrayQueue.new
-    q.pop.must_be_nil
+    _(q.pop).must_be_nil
   end
 
   it 'should act as a queue' do
@@ -21,13 +21,13 @@ describe Adrian::ArrayQueue do
     q.push(2)
     q.push(3)
 
-    q.length.must_equal 3
+    _(q.length).must_equal 3
 
-    q.pop.value.must_equal 1
-    q.pop.value.must_equal 2
-    q.pop.value.must_equal 3
-    q.pop.must_be_nil
+    _(q.pop.value).must_equal 1
+    _(q.pop.value).must_equal 2
+    _(q.pop.value).must_equal 3
+    _(q.pop).must_be_nil
 
-    q.length.must_equal 0
+    _(q.length).must_equal 0
   end
 end

--- a/test/composite_queue_test.rb
+++ b/test/composite_queue_test.rb
@@ -9,7 +9,7 @@ describe Adrian::CompositeQueue do
 
   describe "popping" do
     it 'should return nil when all queues are empty' do
-      @q.pop.must_be_nil
+      _(@q.pop).must_be_nil
     end
 
     it 'should return an item from the first queue that has items' do
@@ -18,27 +18,27 @@ describe Adrian::CompositeQueue do
       @q2.push(3)
       @q2.push(4)
 
-      @q.pop.value.must_equal(1)
-      @q.pop.value.must_equal(2)
-      @q.pop.value.must_equal(3)
-      @q.pop.value.must_equal(4)
-      @q.pop.must_be_nil
-      @q1.pop.must_be_nil
-      @q2.pop.must_be_nil
+      _(@q.pop.value).must_equal(1)
+      _(@q.pop.value).must_equal(2)
+      _(@q.pop.value).must_equal(3)
+      _(@q.pop.value).must_equal(4)
+      _(@q.pop).must_be_nil
+      _(@q1.pop).must_be_nil
+      _(@q2.pop).must_be_nil
     end
 
     it 'sets the original queue on the item' do
       @q1.push(1)
       @q2.push(2)
 
-      @q.pop.queue.must_equal @q1
-      @q.pop.queue.must_equal @q2
+      _(@q.pop.queue).must_equal @q1
+      _(@q.pop.queue).must_equal @q2
     end
   end
 
   describe "pushing" do
     it "should not be allowed" do
-      lambda { @q.push(1) }.must_raise(RuntimeError)
+      _(lambda { @q.push(1) }).must_raise(RuntimeError)
     end
   end
 end

--- a/test/directory_queue_test.rb
+++ b/test/directory_queue_test.rb
@@ -24,14 +24,14 @@ describe Adrian::DirectoryQueue do
     @q.push(item2)
     @q.push(item3)
 
-    @q.length.must_equal 3
+    _(@q.length).must_equal 3
 
-    @q.pop.must_equal Adrian::FileItem.new(item1)
-    @q.pop.must_equal Adrian::FileItem.new(item2)
-    @q.pop.must_equal Adrian::FileItem.new(item3)
-    @q.pop.must_be_nil
+    _(@q.pop).must_equal Adrian::FileItem.new(item1)
+    _(@q.pop).must_equal Adrian::FileItem.new(item2)
+    _(@q.pop).must_equal Adrian::FileItem.new(item3)
+    _(@q.pop).must_be_nil
 
-    @q.length.must_equal 0
+    _(@q.length).must_equal 0
   end
 
   describe 'file backend' do
@@ -63,7 +63,7 @@ describe Adrian::DirectoryQueue do
         one_hour = 3_600
 
         Time.stub(:now, reserved_item.updated_at + one_hour - 1) do
-          assert_equal nil, @q.pop
+          assert_nil(@q.pop)
         end
 
         Time.stub(:now, reserved_item.updated_at + one_hour) do
@@ -85,18 +85,18 @@ describe Adrian::DirectoryQueue do
         def @q.files
           [ 'no/longer/exists' ]
         end
-        assert_equal nil, @q.pop
+        assert_nil(@q.pop)
       end
 
       it "only provides normal files" do
         not_file = Dir.mktmpdir('directory_queue_x', @q.available_path)
-        assert_equal nil, @q.pop
+        assert_nil(@q.pop)
       end
 
       it "sets the logger on the item" do
-        @item.logger.must_be_nil
+        _(@item.logger).must_be_nil
         @q.push(@item)
-        @q.pop.logger.must_equal @logger
+        _(@q.pop.logger).must_equal @logger
       end
 
       describe "items list" do
@@ -108,18 +108,18 @@ describe Adrian::DirectoryQueue do
         end
 
         it "populates items list on first pop" do
-          items_count.must_equal 0
+          _(items_count).must_equal 0
           @q.push(@item1)
           @q.push(@item2)
-          items_count.must_equal 0
+          _(items_count).must_equal 0
 
           @q.pop
-          items_count.must_equal 1
+          _(items_count).must_equal 1
         end
 
         it "populates items list when #include? is used" do
           @q.push(@item1)
-          items_count.must_equal 0
+          _(items_count).must_equal 0
           assert @q.include?(@item1)
         end
 
@@ -128,26 +128,26 @@ describe Adrian::DirectoryQueue do
             @q.push(@item1)
             @q.push(@item2)
             @q.pop
-            items_count.must_equal 1
+            _(items_count).must_equal 1
 
             @q.push(@item3)
             @q.push(@item4)
             refute @q.include?(@item4)
-            items_count.must_equal 1
+            _(items_count).must_equal 1
 
             @q.pop
-            items_count.must_equal 0
+            _(items_count).must_equal 0
           end
 
           it "and #pop is called" do
             @q.pop
             assert @q.include?(@item4)
-            items_count.must_equal 1
+            _(items_count).must_equal 1
           end
 
           it "and #include? is called" do
             assert @q.include?(@item3)
-            items_count.must_equal 2
+            _(items_count).must_equal 2
           end
         end
       end
@@ -179,24 +179,24 @@ describe Adrian::DirectoryQueue do
       it 'should add a delay filter if the :delay option is given' do
         q = Adrian::DirectoryQueue.create(:path => Dir.mktmpdir('dir_queue_test'))
         filter = q.filters.find {|filter| filter.is_a?(Adrian::Filters::Delay)}
-        filter.must_equal nil
+        assert_nil(filter)
 
         q = Adrian::DirectoryQueue.create(:path => Dir.mktmpdir('dir_queue_test'), :delay => 300)
         filter = q.filters.find {|filter| filter.is_a?(Adrian::Filters::Delay)}
-        filter.wont_equal nil
-        filter.duration.must_equal 300
+        _(filter).wont_equal nil
+        _(filter.duration).must_equal 300
       end
 
       it 'should add a lock filter that can be configured with the :lock_duration option' do
         q = Adrian::DirectoryQueue.create(:path => Dir.mktmpdir('dir_queue_test'))
         filter = q.filters.find {|filter| filter.is_a?(Adrian::Filters::FileLock)}
-        filter.wont_equal nil
-        filter.duration.must_equal 3600 # default value
+        _(filter).wont_equal nil
+        _(filter.duration).must_equal 3600 # default value
 
         q = Adrian::DirectoryQueue.create(:path => Dir.mktmpdir('dir_queue_test'), :lock_duration => 300)
         filter = q.filters.find {|filter| filter.is_a?(Adrian::Filters::FileLock)}
-        filter.wont_equal nil
-        filter.duration.must_equal 300
+        _(filter).wont_equal nil
+        _(filter.duration).must_equal 300
       end
     end
   end

--- a/test/dispatcher_lifecycle_test.rb
+++ b/test/dispatcher_lifecycle_test.rb
@@ -25,11 +25,11 @@ describe "Adrian::Dispatcher lifecycle" do
 
         sleep(0.5)
 
-        @q.pop.must_be_nil
+        _(@q.pop).must_be_nil
 
-        $done_items.must_equal([1,2,3])
+        _($done_items).must_equal([1,2,3])
 
-        @dispatcher.running.must_equal false
+        _(@dispatcher.running).must_equal false
       end
     end
 
@@ -45,11 +45,11 @@ describe "Adrian::Dispatcher lifecycle" do
 
         sleep(0.5)
 
-        @q.pop.must_be_nil
+        _(@q.pop).must_be_nil
 
-        $done_items.must_equal([1,2,3])
+        _($done_items).must_equal([1,2,3])
 
-        @dispatcher.running.must_equal true
+        _(@dispatcher.running).must_equal true
         t.kill
       end
     end
@@ -67,15 +67,15 @@ describe "Adrian::Dispatcher lifecycle" do
 
       sleep(0.5)
 
-      @dispatcher.running.must_equal true
-      t.status.wont_equal false
+      _(@dispatcher.running).must_equal true
+      _(t.status).wont_equal false
 
       @dispatcher.stop
 
       sleep(0.5)
 
-      @dispatcher.running.must_equal false
-      t.status.must_equal false
+      _(@dispatcher.running).must_equal false
+      _(t.status).must_equal false
     end
   end
 

--- a/test/dispatcher_test.rb
+++ b/test/dispatcher_test.rb
@@ -33,7 +33,7 @@ describe Adrian::Dispatcher do
 
       @dispatcher.start(@q, @worker)
 
-      $done_items.must_equal([1, 2, 3])
+      _($done_items).must_equal([1, 2, 3])
     end
   end
 
@@ -48,7 +48,7 @@ describe Adrian::Dispatcher do
     it 'skips the old items' do
       @dispatcher.start(@q, @worker)
 
-      $done_items.must_equal([1, 3])
+      _($done_items).must_equal([1, 3])
     end
 
     it 'calls the handler for Adrian::Queue::ItemTooOldError' do
@@ -62,9 +62,9 @@ describe Adrian::Dispatcher do
 
       @dispatcher.start(@q, @worker)
 
-      handled_items.must_equal [@old_item]
-      handled_exceptions.size.must_equal 1
-      handled_exceptions.first.must_be_instance_of Adrian::Queue::ItemTooOldError
+      _(handled_items).must_equal [@old_item]
+      _(handled_exceptions.size).must_equal 1
+      _(handled_exceptions.first).must_be_instance_of Adrian::Queue::ItemTooOldError
     end
   end
 
@@ -87,13 +87,13 @@ describe Adrian::Dispatcher do
       end
 
       @dispatcher.work_done(1, nil)
-      @q.pop.must_be_nil
+      _(@q.pop).must_be_nil
 
       @dispatcher.work_done(1, nil, nil)
-      @q.pop.must_be_nil
+      _(@q.pop).must_be_nil
 
       @dispatcher.work_done(1, nil, RuntimeError.new)
-      @q.pop.value.must_equal 1
+      _(@q.pop.value).must_equal 1
     end
   end
 end

--- a/test/failure_handler_test.rb
+++ b/test/failure_handler_test.rb
@@ -15,15 +15,15 @@ describe Adrian::FailureHandler do
   it "should match rules in the order they were added" do
     block = @handler.handle(RuntimeError.new)
     assert block
-    block.call.must_equal :runtime
+    _(block.call).must_equal(:runtime)
 
     block = @handler.handle(StandardError.new)
     assert block
-    block.call.must_equal :standard
+    _(block.call).must_equal(:standard)
   end
 
   it "should do nothing when no rules match" do
-    @handler.handle(Exception.new).must_be_nil
+    _(@handler.handle(Exception.new)).must_be_nil
   end
 
   describe "the success rule" do
@@ -33,11 +33,11 @@ describe Adrian::FailureHandler do
     end
 
     it "should match when there is no exception" do
-      @handler.handle(RuntimeError.new).must_be_nil
+      _(@handler.handle(RuntimeError.new)).must_be_nil
 
       block = @handler.handle(nil)
       assert block
-      block.call.must_equal :success
+      _(block.call).must_equal(:success)
     end
   end
 

--- a/test/file_item_test.rb
+++ b/test/file_item_test.rb
@@ -28,13 +28,13 @@ describe Adrian::FileItem do
   describe 'updated_at' do
 
     it 'is the atime of the file' do
-      @item.updated_at.must_equal File.atime(@item.path)
+      _(@item.updated_at).must_equal(File.atime(@item.path))
     end
 
     it 'is nil when moved by another process' do
       item = Adrian::FileItem.new('moved/during/initialize')
       assert_equal false, item.exist?
-      assert_equal nil,   item.updated_at
+      assert_nil(item.updated_at)
     end
 
     it 'is cached' do
@@ -51,13 +51,13 @@ describe Adrian::FileItem do
   describe 'created_at' do
 
     it 'is the mtime of the file' do
-      @item.created_at.must_equal File.mtime(@item.path)
+      _(@item.created_at).must_equal(File.mtime(@item.path))
     end
 
     it 'is nil when moved by another process' do
       item = Adrian::FileItem.new('moved/during/initialize')
       assert_equal false, item.exist?
-      assert_equal nil,   item.created_at
+      assert_nil(item.created_at)
     end
 
     it 'is cached' do
@@ -100,13 +100,13 @@ describe Adrian::FileItem do
     it 'does not change the atime' do
       atime = File.atime(@item.path)
       @item.move(@destination)
-      File.atime(@item.path).must_equal atime
+      _(File.atime(@item.path)).must_equal(atime)
     end
 
     it 'does not change the mtime' do
       mtime = File.mtime(@item.path)
       @item.move(@destination)
-      File.mtime(@item.path).must_equal mtime
+      _(File.mtime(@item.path)).must_equal(mtime)
     end
 
   end
@@ -126,8 +126,8 @@ describe Adrian::FileItem do
       now = (Time.now - 100)
       Time.stub(:now, now) { @item.touch }
 
-      now.to_i.wont_equal atime
-      File.atime(@item.path).to_i.must_equal now.to_i
+      _(now.to_i).wont_equal(atime)
+      _(File.atime(@item.path).to_i).must_equal(now.to_i)
     end
 
     it 'does not change the mtime' do
@@ -136,8 +136,8 @@ describe Adrian::FileItem do
       now = (Time.now - 100)
       Time.stub(:new, now) { @item.touch }
 
-      now.to_i.wont_equal mtime
-      File.mtime(@item.path).to_i.must_equal mtime
+      _(now.to_i).wont_equal(mtime)
+      _(File.mtime(@item.path).to_i).must_equal(mtime)
     end
 
   end

--- a/test/girl_friday_dispatcher_test.rb
+++ b/test/girl_friday_dispatcher_test.rb
@@ -22,7 +22,7 @@ describe Adrian::GirlFridayDispatcher do
 
       @dispatcher.start(@q, worker)
 
-      $done_items.sort.must_equal([1, 2, 3])
+      _($done_items.sort).must_equal([1, 2, 3])
     end
   end
 end

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -1,4 +1,5 @@
 require_relative 'test_helper'
+require_relative '../lib/adrian/queue.rb'
 
 describe Adrian::Queue do
   class TestQueue < Adrian::Queue

--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -20,11 +20,11 @@ describe Adrian::Queue do
     it 'validates the age of items' do
       item = Adrian::QueueItem.new('value', Time.now)
       @q.push(item)
-      @q.pop.must_equal item
+      _(@q.pop).must_equal item
 
       item = Adrian::QueueItem.new('value', Time.now - 120)
       @q.push(item)
-      lambda { @q.pop }.must_raise(Adrian::Queue::ItemTooOldError)
+      _(lambda { @q.pop }).must_raise(Adrian::Queue::ItemTooOldError)
     end
 
   end
@@ -34,16 +34,16 @@ describe Adrian::Queue do
 
     item = Adrian::QueueItem.new('value', Time.now)
 
-    item.queue.must_be_nil
+    _(item.queue).must_be_nil
 
     q.push(item)
 
-    item.queue.must_be_nil
+    _(item.queue).must_be_nil
 
     popped_item = q.pop
 
-    popped_item.must_equal item
-    item.queue.must_equal q
+    _(popped_item).must_equal item
+    _(item.queue).must_equal q
   end
 
 end

--- a/test/rotating_directory_queue_test.rb
+++ b/test/rotating_directory_queue_test.rb
@@ -31,8 +31,8 @@ describe Adrian::RotatingDirectoryQueue do
       @item2.move(tomorrows_directory)
       @item3.move(@root_path)
 
-      @q.pop.must_equal @item1
-      @q.pop.must_be_nil
+      _(@q.pop).must_equal @item1
+      _(@q.pop).must_be_nil
     end
   end
 
@@ -48,7 +48,7 @@ describe Adrian::RotatingDirectoryQueue do
       assert_equal false, File.exist?(original_path)
       assert_equal true,  File.exist?(File.join(@q.available_path, @item.name))
 
-      @item.path.must_equal File.join(@root_path, Time.now.strftime('%Y-%m-%d'), @item.name)
+      _(@item.path).must_equal File.join(@root_path, Time.now.strftime('%Y-%m-%d'), @item.name)
     end
   end
 


### PR DESCRIPTION
### Description

Prevents a race condition where multiple processes (or MTC k8s containers attached to the same volume) might attempt to process the same file until the `touch` is completed.

### References

https://zendesk.atlassian.net/browse/EM-6860

### Risks

Low-risk change.

1. Changes when timestamps are modified.
2. Merging this PR will not change the version of the gem being used in other applications. We will still have to publish the changes to rubygems and change the gem version in mtc and mpq.
